### PR TITLE
Uses a default port if one is not provided

### DIFF
--- a/ozwcp.cpp
+++ b/ozwcp.cpp
@@ -770,7 +770,7 @@ int32 main(int32 argc, char* argv[])
 {
 	int32 i;
 	extern char *optarg;
-	long webport;
+	long webport = DEFAULT_PORT;
 	char *ptr;
 
 	while ((i = getopt(argc, argv, "dp:")) != EOF)

--- a/ozwcp.h
+++ b/ozwcp.h
@@ -51,6 +51,7 @@
 using namespace OpenZWave;
 
 #define MAX_NODES 255
+#define DEFAULT_PORT 8090
 
 extern const char *valueGenreStr(ValueID::ValueGenre);
 extern ValueID::ValueGenre valueGenreNum(char const *);


### PR DESCRIPTION
Instead of using the random value that was in memory, explicitly sets the port variable to a default value.