### PR TITLE
Set initialize to be default on enter press

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -67,16 +67,16 @@
                     </div>
                     <br>
                     <div style="float: left;">
-                        <button class="btn btn-default" name="reset" type="submit" style="text-align: center;" onclick="var r=confirm('Do you really want to completely reset the  interface?'); if (r) return DoDevPost('reset'); else return false;">Reset</button>
+                        <button class="btn btn-default" name="reset" type="button" style="text-align: center;" onclick="var r=confirm('Do you really want to completely reset the  interface?'); if (r) return DoDevPost('reset'); else return false;">Reset</button>
                     </div>
                     <div style="float: left; padding-left: 7px;">
-                        <button class="btn btn-default" name="sreset" type="submit" style="text-align: center;" onclick="return DoDevPost('sreset');">Soft Reset</button>
+                        <button class="btn btn-default" name="sreset" type="button" style="text-align: center;" onclick="return DoDevPost('sreset');">Soft Reset</button>
                     </div>
                     <div style="float: right;">
                         <button class="btn btn-default" name="initialize" type="submit" style="text-align: center;" onclick="return DoDevPost('open');">Initialize</button>
                     </div>
                     <div style="float: right; padding-right: 7px;">
-                        <button class="btn btn-default" name="close" type="submit" style="text-align: left;" onclick=" return DoDevPost('close');">Close</button>
+                        <button class="btn btn-default" name="close" type="button" style="text-align: left;" onclick=" return DoDevPost('close');">Close</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
This is a pretty minor/nitpicky thing, but I keep entering my device path and smacking enter, and being greeted by a "are you sure you want to hard reset?" js popup. This switches the default button on enter press in the device path field to fire the initialize instead of a hard reset confirmation dialog. Thanks!