### PR TITLE
Fixed deprecated warnings when using libmicrohttpd-0.9.50

### DIFF
--- a/webserver.cpp
+++ b/webserver.cpp
@@ -106,7 +106,13 @@ static int web_send_data (struct MHD_Connection *connection, const char *data,
 	struct MHD_Response *response;
 	int ret;
 
-	response = MHD_create_response_from_data(strlen(data), (void *)data, free ? MHD_YES : MHD_NO, copy ? MHD_YES : MHD_NO);
+	if (!copy && ! free)
+		response = MHD_create_response_from_buffer(strlen(data), (void *) data, MHD_RESPMEM_PERSISTENT);
+	else if (copy)
+		response = MHD_create_response_from_buffer(strlen(data), (void *) data, MHD_RESPMEM_MUST_COPY);
+	else
+		response = MHD_create_response_from_buffer(strlen(data), (void *) data, MHD_RESPMEM_MUST_FREE);
+
 	if (response == NULL)
 		return MHD_NO;
 	if (ct != NULL)
@@ -161,7 +167,7 @@ int web_send_file (struct MHD_Connection *conn, const char *filename, const int 
 	if (stat(filename, &buf) == -1 ||
 			((fp = fopen(filename, "r")) == NULL)) {
 		if (strcmp(p, "xml") == 0)
-			response = MHD_create_response_from_data(0, (void *)"", MHD_NO, MHD_NO);
+			response = MHD_create_response_from_buffer(0, (void *) "", MHD_RESPMEM_PERSISTENT);
 		else {
 			int len = strlen(FNF) + strlen(filename) - 1; // len(%s) + 1 for \0
 			char *s = (char *)malloc(len);
@@ -170,7 +176,7 @@ int web_send_file (struct MHD_Connection *conn, const char *filename, const int 
 				exit(1);
 			}
 			snprintf(s, len, FNF, filename);
-			response = MHD_create_response_from_data(len, (void *)s, MHD_YES, MHD_NO); // free
+			response = MHD_create_response_from_buffer(len, (void *) s, MHD_RESPMEM_MUST_FREE); // free
 		}
 	} else
 		response = MHD_create_response_from_callback(buf.st_size, 32 * 1024, &web_read_file, fp,


### PR DESCRIPTION
I'm using latest version of libmicrohttpd (version 0.9.50) and the following warnings make the compilation fail. I did not want to remove -Werror so instead fixed the code to use newest function. Here are the warnings that this PR fixes.

> webserver.cpp: In function ‘int web_send_data(MHD_Connection*, const char*, int, bool, bool, const char*)’:
webserver.cpp:109:13: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
  response = MHD_create_response_from_data(strlen(data), (void *)data, free ? MHD_YES : MHD_NO, copy ? MHD_YES : MHD_NO);
             ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:109:13: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
  response = MHD_create_response_from_data(strlen(data), (void *)data, free ? MHD_YES : MHD_NO, copy ? MHD_YES : MHD_NO);
             ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:109:119: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
  response = MHD_create_response_from_data(strlen(data), (void *)data, free ? MHD_YES : MHD_NO, copy ? MHD_YES : MHD_NO);
                                                                                                                       ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp: In function ‘int web_send_file(MHD_Connection*, const char*, int, bool)’:
webserver.cpp:164:15: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(0, (void *)"", MHD_NO, MHD_NO);
               ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:164:15: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(0, (void *)"", MHD_NO, MHD_NO);
               ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:164:74: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(0, (void *)"", MHD_NO, MHD_NO);
                                                                          ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:173:15: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(len, (void *)s, MHD_YES, MHD_NO); // free
               ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:173:15: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(len, (void *)s, MHD_YES, MHD_NO); // free
               ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
webserver.cpp:173:76: error: ‘MHD_Response* MHD_create_response_from_data(size_t, void*, int, int)’ is deprecated: MHD_create_response_from_data() is deprecated, use MHD_create_response_from_buffer() [-Werror=deprecated-declarations]
    response = MHD_create_response_from_data(len, (void *)s, MHD_YES, MHD_NO); // free
                                                                            ^
In file included from webserver.cpp:58:0:
../libmicrohttpd-0.9.50/src/include/microhttpd.h:2068:1: note: declared here
 MHD_create_response_from_data (size_t size,
 ^
cc1plus: all warnings being treated as errors
Makefile:49: recipe for target 'webserver.o' failed
make: *** [webserver.o] Error 1
