### PR TITLE
Fixed 255 limit for values

### DIFF
--- a/ozwcp.cpp
+++ b/ozwcp.cpp
@@ -414,7 +414,7 @@ MyValue *MyNode::lookup (string data)
 /*
  * Returns a count of values
  */
-int32 MyNode::getValueCount ()
+uint16 MyNode::getValueCount ()
 {
 	return values.size();
 }
@@ -422,7 +422,7 @@ int32 MyNode::getValueCount ()
 /*
  * Returns an n'th value
  */
-MyValue *MyNode::getValue (uint8 n)
+MyValue *MyNode::getValue (uint16 n)
 {
 	if (n < values.size())
 		return values[n];

--- a/ozwcp.h
+++ b/ozwcp.h
@@ -88,9 +88,9 @@ public:
   void addValue(ValueID id);
   void removeValue(ValueID id);
   void saveValue(ValueID id);
-  int32 getValueCount();
+  uint16 getValueCount();
   static MyValue *lookup(string id);
-  MyValue *getValue(uint8 n);
+  MyValue *getValue(uint16 n);
   uint32 getTime() { return mtime; }
   void setTime(uint32 t) { mtime = t; }
   static bool getAnyChanged() { return nodechanged; }

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -219,13 +219,13 @@ void Webserver::web_get_groups (int n, TiXmlElement *ep)
 
 /*
  * web_get_values
- * Retreive class values based on genres
+ * Retrieve class values based on genres
  */
 void Webserver::web_get_values (int i, TiXmlElement *ep)
 {
-	int32 idcnt = nodes[i]->getValueCount();
+	uint16 idcnt = nodes[i]->getValueCount();
 
-	for (int j = 0; j < idcnt; j++) {
+	for (uint16 j = 0; j < idcnt; j++) {
 		TiXmlElement* valueElement = new TiXmlElement("value");
 		MyValue *vals = nodes[i]->getValue(j);
 		ValueID id = vals->getId();


### PR DESCRIPTION
I have a Yales lock that has 273 Values. I noticed that when I clicked on the lock, the control panel shows duplicated values and is missing many others. After troubleshooting this, I located the root cause.

> MyNode::getValue (uint8 n)

That parameter supports range 0-255 so when I was requesting anything above 255, it seems like it was looping and starting form zero again. :( After my fix, the UI now shows correctly all values of my lock.