### PR TITLE
Autoconnect default device; autoinit connected device.

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -46,7 +46,7 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     </head>
-    <body onload="return BED();" onmousemove="PosToolTip(event);">
+    <body onload="GetDefaultDevice();" onmousemove="PosToolTip(event);">
         <h1 id="title">OpenZWave Control Panel</h1>
         <div class="container-fluid">
             <div class="col-xs-6 col-sm-4">
@@ -78,6 +78,7 @@
                     <div style="float: right; padding-right: 7px;">
                         <button class="btn btn-default" name="close" type="button" style="text-align: left;" onclick=" return DoDevPost('close');">Close</button>
                     </div>
+
                 </form>
             </div>
             <div class="col-xs-6 col-sm-4">

--- a/cp.js
+++ b/cp.js
@@ -71,6 +71,30 @@ if (window.XMLHttpRequest) { // code for IE7+, Firefox, Chrome, Opera, Safari
     racphttp = new ActiveXObject("Microsoft.XMLHTTP");
 }
 
+function GetDefaultDevice() {
+    var devhttp;
+    if (window.XMLHttpRequest) { // code for IE7+, Firefox, Chrome, Opera, Safari
+        devhttp = new XMLHttpRequest();
+    } else {
+        devhttp = new ActiveXObject("Microsoft.XMLHTTP");
+    }
+    devhttp.onreadystatechange = function() {
+        if (devhttp.readyState==4 && devhttp.status==200){
+            if (devhttp.responseText == 'NULL')
+                document.DevPost.devname.value = '';
+            else
+                document.DevPost.devname.value = devhttp.responseText;
+        }
+        BED();
+    }
+    devhttp.open("GET", "currdev", true);
+    if (window.XMLHttpRequest) { // code for IE7+, Firefox, Chrome, Opera, Safari
+            devhttp.send(null);
+    } else { // code for IE6, IE5
+            devhttp.send();
+    }
+}
+
 function OptionGroup(label, disabled) {
     var element = document.createElement('optgroup');
     if (disabled !== undefined) element.disabled = disabled;
@@ -391,8 +415,7 @@ function PollReply() {
 
 function BED() {
     var forms = document.forms;
-    var off = false;
-    (document.DevPost.devname.value.length == 0) && !document.DevPost.usbb.checked;
+    var off = (document.DevPost.devname.value.length == 0) && !document.DevPost.usbb.checked;
     var info;
 
     tt.setAttribute('id', 'tt');

--- a/webserver.h
+++ b/webserver.h
@@ -58,6 +58,7 @@ class Webserver {
 		void web_get_groups(int i, TiXmlElement *ep);
 		void web_get_values(int i, TiXmlElement *ep);
 		int SendPollResponse(struct MHD_Connection *conn);
+		int SendDeviceListResponse(struct MHD_Connection *conn);
 		const char *SendSceneResponse(struct MHD_Connection *conn, const char *fun, const char *arg1, const char *arg2, const char *arg3);
 		const char *SendTopoResponse(struct MHD_Connection *conn, const char *fun, const char *arg1, const char *arg2, const char *arg3);
 		const char *SendStatResponse(struct MHD_Connection *conn, const char *fun, const char *arg1, const char *arg2, const char *arg3);


### PR DESCRIPTION
I've added a couple features that I've found useful while using ozwcp. They are simple additions that do not really change any existing features (maintaining compatibility), so I thought I should share them and maybe others would also find them useful.

1) A default device can be specified with the environmental variable "OZW_DEFAULT_DEVICE". If no variable is specified or if set to "", no attempt is made to connect a device. 
2) If a device is already connected, the path to the device is automatically filled into the form in cp.html by making a GET request for '/currdev'
3) A xml file listing all nodes can be retrieved with a GET request at '/devices.xml'
