### PR TITLE
Remove need for manual Makefile edits between platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,13 @@ INCLUDES := -I $(OPENZWAVE)/cpp/src -I $(OPENZWAVE)/cpp/src/command_classes/ \
 #GNUTLS := -lgnutls
 
 
+LIBZWAVE := $(wildcard $(OPENZWAVE)/*.a)
 ifeq ($(UNAME), Darwin)
-	LIBZWAVE := $(wildcard $(OPENZWAVE)/cpp/lib/mac/*.a)
 	LIBUSB := -framework IOKit -framework CoreFoundation
 	LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) $(ARCH) -lresolv
 else
 	ARCH := -arch i386 -arch x86_64
 	CFLAGS += $(ARCH)
-	LIBZWAVE := $(wildcard $(OPENZWAVE)/*.a)
 	LIBUSB := -ludev
 	LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) -lresolv
 endif
@@ -52,14 +51,7 @@ endif
 %.o : %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $<
 
-all: defs ozwcp
-
-
-defs:
-ifeq ($(LIBZWAVE),)
-	@echo Please edit the Makefile to avoid this error message.
-	@exit 1
-endif
+all: ozwcp
 
 ozwcp.o: ozwcp.h webserver.h $(OPENZWAVE)/cpp/src/Options.h $(OPENZWAVE)/cpp/src/Manager.h \
 	$(OPENZWAVE)/cpp/src/Node.h $(OPENZWAVE)/cpp/src/Group.h \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ LDFLAGS	:= $(DEBUG_LDFLAGS)
 
 OPENZWAVE := ../open-zwave/
 LIBMICROHTTPD := -L/usr/local/lib/ -lmicrohttpd
+UNAME := $(shell uname)
 
 INCLUDES := -I $(OPENZWAVE)/cpp/src -I $(OPENZWAVE)/cpp/src/command_classes/ \
 	-I $(OPENZWAVE)/cpp/src/value_classes/ -I $(OPENZWAVE)/cpp/src/platform/ \
@@ -32,17 +33,18 @@ INCLUDES := -I $(OPENZWAVE)/cpp/src -I $(OPENZWAVE)/cpp/src/command_classes/ \
 # Remove comment below for gnutls support
 #GNUTLS := -lgnutls
 
-# for Linux uncomment out next three lines
-LIBZWAVE := $(wildcard $(OPENZWAVE)/*.a)
-#LIBUSB := -ludev
-#LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) -lresolv
 
-# for Mac OS X comment out above 2 lines and uncomment next 5 lines
-#ARCH := -arch i386 -arch x86_64
-#CFLAGS += $(ARCH)
-#LIBZWAVE := $(wildcard $(OPENZWAVE)/cpp/lib/mac/*.a)
-LIBUSB := -framework IOKit -framework CoreFoundation
-LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) $(ARCH) -lresolv
+ifeq ($(UNAME), Darwin)
+	LIBZWAVE := $(wildcard $(OPENZWAVE)/cpp/lib/mac/*.a)
+	LIBUSB := -framework IOKit -framework CoreFoundation
+	LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) $(ARCH) -lresolv
+else
+	ARCH := -arch i386 -arch x86_64
+	CFLAGS += $(ARCH)
+	LIBZWAVE := $(wildcard $(OPENZWAVE)/*.a)
+	LIBUSB := -ludev
+	LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) -lresolv
+endif
 
 %.o : %.cpp
 	$(CXX) $(CFLAGS) $(INCLUDES) -o $@ $<

--- a/README
+++ b/README
@@ -34,16 +34,6 @@ optional.
 All three of these installations should share live in the same directory
 (share a common parent). The ozwcp Makefile assumes this.
 
-See Makefile for comments about Mac OS X support. Note: Makefile is
-configured to build on Mac OS X; to build on Linux, you will need to
-comment out lines under
-
-  # for Mac OS X comment
-
-and uncomment lines under
-
-  # for Linux uncomment
-
 Currently Windows is not supported. It should be possible to port this
 to the Window's cygwin environment if anyone is interested in pursing that
 option.


### PR DESCRIPTION
uname is not available on Windows, but the platform is not supported at the moment anyhow.

I tested this on OSX 10.12.4 and Ubuntu 16.10.

Also it seems that the open-zwave build puts the build artifacts (.a, .dylib) in the root directory now of the build the same way it does on Linux so there is not a need for the LIBZWAVE special case.