### PR TITLE
Fixes for group editor, Update Makefile to detect macOS and allow bui…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,28 +21,45 @@ DEBUG_LDFLAGS	:= -g
 CFLAGS	:= -c $(DEBUG_CFLAGS)
 LDFLAGS	:= $(DEBUG_LDFLAGS) -v
 
-OPENZWAVE := ../open-zwave/
 LIBMICROHTTPD := -L/usr/local/lib/ -lmicrohttpd
+
+# Remove comment below for gnutls support
+#GNUTLS := -lgnutls
+
+# Determine the system we are building on
+UNAME  := $(shell uname -s)
+
+# Select proper options for macOS vs others
+ifeq ($(UNAME),Darwin)
+$(info setting variables for macOS)
+ARCH := -arch x86_64
+CFLAGS += $(ARCH)
+LIBZWAVE_PAT := libopenzwave.dylib
+LIBUSB := -framework IOKit -framework CoreFoundation
+else
+$(info setting variables for $(UNAME))
+LIBZWAVE_PAT := *.a
+LIBUSB := -ludev
+endif
+
+# Check if library exists in either parrent directory or ../open-zwave
+OPENZWAVE := ..
+LIBZWAVE := $(wildcard $(OPENZWAVE)/$(LIBZWAVE_PAT))
+ifeq ($(LIBZWAVE),)
+  OPENZWAVE := ../open-zwave
+  LIBZWAVE := $(wildcard $(OPENZWAVE)/$(LIBZWAVE_PAT))
+  ifeq ($(LIBZWAVE),)
+    $(error OpenZWave library "$(LIBZWAVE_PAT)" not found in either .. or ../open-zwave folder)
+  endif
+endif
+$(info OpenZWave library found: $(LIBZWAVE))
+
+LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) $(ARCH) -lresolv
 
 INCLUDES := -I $(OPENZWAVE)/cpp/src -I $(OPENZWAVE)/cpp/src/command_classes/ \
 	-I $(OPENZWAVE)/cpp/src/value_classes/ -I $(OPENZWAVE)/cpp/src/platform/ \
 	-I $(OPENZWAVE)/cpp/src/platform/unix -I $(OPENZWAVE)/cpp/tinyxml/ \
 	-I /usr/local/include/
-
-# Remove comment below for gnutls support
-#GNUTLS := -lgnutls
-
-# for Linux uncomment out next three lines
-LIBZWAVE := $(wildcard $(OPENZWAVE)/*.a)
-LIBUSB := -ludev
-LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) -lresolv
-
-# for Mac OS X comment out above 2 lines and uncomment next 5 lines
-#ARCH := -arch i386 -arch x86_64
-#CFLAGS += $(ARCH)
-#LIBZWAVE := $(wildcard $(OPENZWAVE)/cpp/lib/mac/*.a)
-#LIBUSB := -framework IOKit -framework CoreFoundation
-#LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) $(ARCH) -lresolv
 
 %.o : %.cpp
 	$(CXX) $(CFLAGS) $(INCLUDES) -o $@ $<
@@ -50,22 +67,7 @@ LIBS := $(LIBZWAVE) $(GNUTLS) $(LIBMICROHTTPD) -pthread $(LIBUSB) -lresolv
 %.o : %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $<
 
-all: defs ozwcp
-
-
-defs:
-ifeq ($(LIBZWAVE),)
-	@echo Please edit the Makefile to avoid this error message.
-	@exit 1
-endif
-
-ozwcp.o: ozwcp.h webserver.h $(OPENZWAVE)/cpp/src/Options.h $(OPENZWAVE)/cpp/src/Manager.h \
-	$(OPENZWAVE)/cpp/src/Node.h $(OPENZWAVE)/cpp/src/Group.h \
-	$(OPENZWAVE)/cpp/src/Notification.h $(OPENZWAVE)/cpp/src/platform/Log.h
-
-webserver.o: webserver.h ozwcp.h $(OPENZWAVE)/cpp/src/Options.h $(OPENZWAVE)/cpp/src/Manager.h \
-	$(OPENZWAVE)/cpp/src/Node.h $(OPENZWAVE)/cpp/src/Group.h \
-	$(OPENZWAVE)/cpp/src/Notification.h $(OPENZWAVE)/cpp/src/platform/Log.h
+all: ozwcp
 
 ozwcp:	ozwcp.o webserver.o zwavelib.o $(LIBZWAVE)
 	$(LD) -o $@ $(LDFLAGS) ozwcp.o webserver.o zwavelib.o $(LIBS)
@@ -76,3 +78,6 @@ dist:	ozwcp
 
 clean:
 	rm -f ozwcp *.o
+
+# dummy target, for debugging Makefile
+dummy:

--- a/README
+++ b/README
@@ -1,62 +1,65 @@
-OZWCP is unmaintained. If anybody is interested in maintaining it please let us know.
+OZWCP is largely unmaintained, getting occasional bug fixes only. If anybody is
+interested in maintaining it please let us know. There is a new OZW GUI being
+developed in ozw-admin repository that should replace the functionality of
+OpenZWave Control Panel.
 
-Use at your own risk!
+Update 29 July 2019
 
-(There is a new OZW GUI being developed in ozw-admin repository that should replace the functionality of OZWCP)
-
-
-
-
-
-OpenZWave Control Panel v0.2a 8/8/2011
-
-Welcome to a very alpha release of the OpenZWave Control Panel.
+Bugfix for groups, build detection macOS versus linux, can build inside or
+outside of open-zwave directory
 
 OVERVIEW
 
-This README for the OpenZWave Control Panel will attempt to provide the
-necessary information to compile, use and develop.
-
 The OpenZWave Control Panel (ozwcp for short) is an application built on
-the OpenZWave library http://code.google.com/p/open-zwave/ that permits
+the OpenZWave library https://github.com/OpenZWave/open-zwave that permits
 users to query, manage and monitor Z-Wave nodes and networks. It provides a
 web based user interface using AJAX principles.
 
-The code is very new, as is the library, so bugs will be present. This tool
-will allow the basic use of Z-Wave devices as well as help push forward the
-development of the OpenZWave library.
+OpenZWave Control Panel was updated in 2019 to support OpenZWave 1.6
+(being master branch at that time)
+
+A feature lacking from OZW 1.6 is "Bitfields".
 
 INSTALLATION
 
-To install ozwcp, visit http://code.google.com/p/openzwave-control-panel/
-and click on the "source" tab. You will need an svn client to check out a
-copy of the sources.
+The web server is based on GNU's libmicrohttpd library available at
 
-You will need a copy of the latest version of the OpenZWave library at
-http://code.google.com/p/open-zwave/. Use the "source" tab on that project
-to get a copy.
+https://www.gnu.org/software/libmicrohttpd/
 
-ozwcp uses GNU's libmicrohttpd library available at
-http://www.gnu.org/software/libmicrohttpd/. I have set up this library
-using the --enable-messages configure option for debugging but this is
-optional.
+Debian based system:
 
-All three of these installations should share live in the same directory
-(share a common parent). The ozwcp Makefile assumes this.
+apt-get install libmicrohttpd-dev
 
-See Makefile for comments about Mac OS X support. Note: Makefile is
-configured to build on Mac OS X; to build on Linux, you will need to
-comment out lines under
+Mac using Homebrew:
 
-  # for Mac OS X comment
+brew install libmicrohttpd
 
-and uncomment lines under
+If you build libmicrohttpd from source you can use the  --enable-messages
+configure option for debugging.
 
-  # for Linux uncomment
+Install Option 1 - outside of OZW folder.
 
-Currently Windows is not supported. It should be possible to port this
-to the Window's cygwin environment if anyone is interested in pursing that
-option.
+First (shallow) git clone OpenZWave and build it
+
+git clone --depth 1 https://github.com/OpenZWave/open-zwave
+cd open-zwave/
+make
+
+Then:
+
+cd ..
+git clone --depth 1 https://github.com/OpenZWave/open-zwave-control-panel
+cd open-zwave-control-panel/
+make
+
+Install Option 2 - in OZW folder
+
+This was the only option before the 29 july 2019 update... Like option 1,
+but clone the ozwcp repo in the OZW folder.
+
+There is no need to edit the Makefile, the OS and path is detected automatically.
+
+Currently Windows is not supported.
 
 OPERATION
 
@@ -65,11 +68,10 @@ ozwcp currently runs from the command line and takes two flags:
 -d for debugging
 -p <portnum> port number the web server will listen on
 
-Once started, connect to the hostname:postnum that ozwcp is running on
-using a web broswer and you will get to the user interface.
+Default port is 8090
 
-Firefox has been extensively tested. Safari works. Intnernet Explorer
-doesn't work yet. This is also on the to do list.
+Once started, connect to the hostname:postnum that ozwcp is running on
+using a web browser and you will get to the user interface.
 
 ozwcp currently must be run from within its distribution directory. It
 serves files that must be present for it to work properly. You may need to
@@ -77,11 +79,11 @@ run it as root depending on the port number you use.
 
 CAVEATS
 
-This is an alpha release at best. It has only ever worked in a single
-environment. Please report bugs to the OpenZWave google groups mailing list:
-http://groups.google.com/group/openzwave.
+This was build as a proof of concept and is "quite usable" for diagnosis and
+setting stuff...
 
-See the file TODO for a list of things on the to do list.
+Please report bugs to the OpenZWave google groups mailing list:
+http://groups.google.com/group/openzwave.
 
 NOTE
 

--- a/cp.js
+++ b/cp.js
@@ -1432,9 +1432,14 @@ function CreateGroup(ind) {
             // build a list of instances 
             var instances = [String(j)];
             for (var l = 0; l < node.values.length; l++) {
-                instances[l + 1] = j + '.' + node.values[l].instance;
                 instances.push(j + '.' + node.values[l].instance);
             }
+            // On OpenZwave Version 1.6-845-gfe401290, july 2019  OZW adds node 1 endpoint 1 (assuming 1 is the controller)
+            // That is actually instance "2"... So I add it (to enable its display)
+			// See void MultiChannelAssociation::Set(uint8 _groupIdx, uint8 _targetNodeId, uint8 _instance)
+			// Because ozwcp is in "low maintenance mode" and 99.9% of all controllers have ID 1... Hack it...
+            if(j == 1)
+                instances.push('1.2')
 
             // make unique
             instances = instances.filter(function (item, i, ar) {

--- a/cp.js
+++ b/cp.js
@@ -924,7 +924,9 @@ function DoGrpPost() {
     var opts = document.NodePost.groups.options;
     var i;
 
-    for (i = 0; i < opts.length; i++)
+    // Start loop at 1 because index 0 contains the empty "remove" option, selecting this empty label
+    // on its own creates an empty list and thus removes all associations from a group
+    for (i = 1; i < opts.length; i++)
         if (opts[i].selected) {
             params += opts[i].text + ',';
         }
@@ -1419,7 +1421,8 @@ function CreateGroup(ind) {
     grp = 1;
     for (i = 0; i < nodes[ind].groups.length; i++) {
         nodegrp[ind] += '<option value="' + nodes[ind].groups[i].id + '">' + nodes[ind].groups[i].label + ' (' + nodes[ind].groups[i].id + ')</option>';
-        nodegrpgrp[ind][grp] = '<td><div id="nodegrp" name="nodegrp" style="float: right;"><select id="groups" multiple size="8" style="vertical-align: top; margin-left: 5px;">';
+        // Add <option></option> at the start - this empty option allows to define/select an empty group
+        nodegrpgrp[ind][grp] = '<td><div id="nodegrp" name="nodegrp" style="float: right;"><select id="groups" multiple size="8" style="vertical-align: top; margin-left: 5px;"><option></option>';
         k = 0;
         for (j = 1; j < nodes.length; j++) {
             var node = nodes[j];
@@ -1438,10 +1441,9 @@ function CreateGroup(ind) {
                 return ar.indexOf(item) === i;
             });
 
-            // only show when we have found multiple instances
-            if (instances.length <= 2) {
-                instances = [String(j)];
-            }
+            // There used to be code to "only show when we have found multiple instances"
+            // But I think it is clearer (and correct) to show all possible
+            // single and multi instances
 
             if (nodes[ind].groups[i].nodes != null)
                 while (k < nodes[ind].groups[i].nodes.length && nodes[ind].groups[i].nodes[k] < j)


### PR DESCRIPTION
…ld outside of OZW directory.

Bugfixes:
- enable selection and display of single instance and multi instance in groups.
- remove old associations before setting new, this fixes problems with eg
  lifeline group which might accept only one association.
- fixed BUI displays instances versus endpoints needed by association commands

Related to https://github.com/OpenZWave/open-zwave/issues/1895

Qubino ZMNHADX problem with end points and groups