### PR TITLE
Handle undefined items.firstChild

### DIFF
--- a/cp.js
+++ b/cp.js
@@ -281,10 +281,12 @@ function PollReply() {
                         var current = values.getAttribute('current');
                         node_values.value = new Array();
                         for (var l = 0; l < items.length; l++) {
-                            node_values.value[l] = {
-                                item: items[l].firstChild.nodeValue,
-                                selected: (current == items[l].firstChild.nodeValue)
-                            };
+                            if (items[l].firstChild) {
+                                node_values.value[l] = {
+                                    item: items[l].firstChild.nodeValue,
+                                    selected: (current == items[l].firstChild.nodeValue)
+                                };    
+                            }
                         }
                     } else if (node_values.type == 'bitset') {
                         var bits = values.getElementsByTagName('bitset');

--- a/cp.js
+++ b/cp.js
@@ -285,7 +285,12 @@ function PollReply() {
                                 node_values.value[l] = {
                                     item: items[l].firstChild.nodeValue,
                                     selected: (current == items[l].firstChild.nodeValue)
-                                };    
+                                };
+                            } else {
+                                node_values.value[l] = {
+                                    item: "---",
+                                    selected: false
+                                };
                             }
                         }
                     } else if (node_values.type == 'bitset') {
@@ -410,7 +415,7 @@ function PollReply() {
                     SaveNode(curnode);
             }
         }
-        polltmr = setTimeout(Poll, 750);
+        polltmr = setTimeout(Poll, 3000);
     }
 }
 


### PR DESCRIPTION
For me, OZW CP was not showing any devices and console was showing errors about firstChild being undefined.

I'm not sure what exactly causes this, but since this is unmantained anyway, this his a quick hotfix that fixes device display.